### PR TITLE
Fix 7-day average calculation to handle missing data correctly

### DIFF
--- a/src/components/chart-card/chart-card.js
+++ b/src/components/chart-card/chart-card.js
@@ -1,4 +1,5 @@
 import Chart from 'chart.js';
+import { calculateMovingAverage } from '../../utils/math.js';
 
 export class ChartCard extends HTMLElement {
     constructor() {
@@ -244,26 +245,7 @@ export class ChartCard extends HTMLElement {
 
         series.forEach(s => {
             const rawData = normalizedData[s.key];
-            const avgData = [];
-            for (let i = 0; i < rawData.length; i++) {
-                let sum = 0;
-                let count = 0;
-                // Average over available data in the window [i - windowSize + 1, i]
-                for (let j = 0; j < windowSize; j++) {
-                    const idx = i - j;
-                    if (idx >= 0 && rawData[idx] !== null && rawData[idx] !== undefined) {
-                        sum += Number(rawData[idx]);
-                        count++;
-                    }
-                }
-                
-                if (count > 0) {
-                    avgData.push(sum / count);
-                } else {
-                    avgData.push(null);
-                }
-            }
-            movingAverages[s.key] = avgData;
+            movingAverages[s.key] = calculateMovingAverage(rawData, windowSize);
         });
 
         const datasets = [];

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,0 +1,37 @@
+
+/**
+ * Calculates a simple moving average for an array of numbers.
+ * If any value in the window is null or undefined (missing), the average for that window is null.
+ *
+ * @param {Array<number|null>} data - The input data array.
+ * @param {number} windowSize - The size of the moving window.
+ * @returns {Array<number|null>} The calculated moving averages.
+ */
+export function calculateMovingAverage(data, windowSize) {
+    const avgData = [];
+    for (let i = 0; i < data.length; i++) {
+        let sum = 0;
+        let count = 0;
+        let hasMissing = false;
+
+        // check window [i - windowSize + 1, i]
+        for (let j = 0; j < windowSize; j++) {
+            const idx = i - j;
+            if (idx >= 0) {
+                if (data[idx] === null || data[idx] === undefined) {
+                    hasMissing = true;
+                    break;
+                }
+                sum += Number(data[idx]);
+                count++;
+            }
+        }
+
+        if (!hasMissing && count > 0) {
+            avgData.push(sum / count);
+        } else {
+            avgData.push(null);
+        }
+    }
+    return avgData;
+}

--- a/tests/math.test.js
+++ b/tests/math.test.js
@@ -1,0 +1,73 @@
+
+import { calculateMovingAverage } from '../src/utils/math.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('calculateMovingAverage', () => {
+
+    it('should calculate moving average for a simple array', () => {
+        const data = [10, 20, 30, 40, 50];
+        const windowSize = 3;
+        const result = calculateMovingAverage(data, windowSize);
+
+        // Window 1: [10] -> 10
+        // Window 2: [10, 20] -> 15
+        // Window 3: [10, 20, 30] -> 20
+        // Window 4: [20, 30, 40] -> 30
+        // Window 5: [30, 40, 50] -> 40
+        assert.deepStrictEqual(result, [10, 15, 20, 30, 40]);
+    });
+
+    it('should return null if window contains null', () => {
+        const data = [10, 20, 30, null, 50, 60, 70];
+        const windowSize = 3;
+        const result = calculateMovingAverage(data, windowSize);
+
+        // Window 1: [10] -> 10
+        // Window 2: [10, 20] -> 15
+        // Window 3: [10, 20, 30] -> 20
+        // Window 4: [20, 30, null] -> null (missing in window)
+        // Window 5: [30, null, 50] -> null (missing in window)
+        // Window 6: [null, 50, 60] -> null (missing in window)
+        // Window 7: [50, 60, 70] -> 60
+
+        assert.deepStrictEqual(result, [10, 15, 20, null, null, null, 60]);
+    });
+
+    it('should handle undefined as missing', () => {
+        const data = [10, undefined, 30];
+        const windowSize = 2;
+        const result = calculateMovingAverage(data, windowSize);
+
+        // Window 1: [10] -> 10
+        // Window 2: [10, undefined] -> null
+        // Window 3: [undefined, 30] -> null
+
+        assert.deepStrictEqual(result, [10, null, null]);
+    });
+
+    it('should handle window larger than data', () => {
+        const data = [10, 20];
+        const windowSize = 5;
+        const result = calculateMovingAverage(data, windowSize);
+
+        // Window 1: [10] -> 10
+        // Window 2: [10, 20] -> 15
+
+        assert.deepStrictEqual(result, [10, 15]);
+    });
+
+    it('should handle empty array', () => {
+        const data = [];
+        const windowSize = 3;
+        const result = calculateMovingAverage(data, windowSize);
+        assert.deepStrictEqual(result, []);
+    });
+
+    it('should handle all nulls', () => {
+        const data = [null, null, null];
+        const windowSize = 2;
+        const result = calculateMovingAverage(data, windowSize);
+        assert.deepStrictEqual(result, [null, null, null]);
+    });
+});


### PR DESCRIPTION
This change updates the chart's 7-day average calculation to strictly exclude windows containing missing data. Previously, the average would compute using the available data points, potentially creating misleading trends over gaps. Now, if any day in the 7-day window is missing, the average for that window is `null`, resulting in a gap in the chart line. This ensures data integrity and better visualization of missing periods.


---
*PR created automatically by Jules for task [1570491176525402598](https://jules.google.com/task/1570491176525402598) started by @steren*