### PR TITLE
Display non-walking activities in the timeline

### DIFF
--- a/src/components/timeline-day.js
+++ b/src/components/timeline-day.js
@@ -52,6 +52,7 @@ export class TimelineDay extends HTMLElement {
         // Categorize events
         const locationEvents = events.filter(e => e.type === 'location');
         const activityEvents = events.filter(e => e.type === 'activity');
+        const workoutEvents = events.filter(e => e.type === 'workout');
         const weightEvents = events.filter(e => e.type === 'weight');
         const sleepEvents = events.filter(e => e.type === 'sleep');
         const nutritionEvents = events.filter(e => e.type === 'nutrition');
@@ -88,6 +89,40 @@ export class TimelineDay extends HTMLElement {
                 note: stepNotes.length > 0 ? stepNotes.join('; ') : null
             });
         }
+
+        // Workouts (any activity that isn't walking)
+        const workoutIcons = {
+            'Running': '🏃',
+            'Cycling': '🚴',
+            'Swimming': '🏊',
+            'Hiking': '🥾',
+            'Ski': '⛷️',
+            'Multi Sport': '🤸'
+        };
+
+        [...workoutEvents].sort((a, b) => a.timestamp - b.timestamp).forEach(e => {
+            const durationMinutes = e.end_timestamp
+                ? Math.round((e.end_timestamp - e.timestamp) / 60000)
+                : null;
+            const durationStr = durationMinutes
+                ? (durationMinutes >= 60
+                    ? `${Math.floor(durationMinutes / 60)}h ${durationMinutes % 60}m`
+                    : `${durationMinutes}m`)
+                : null;
+
+            const subParts = [];
+            if (e.distance) subParts.push(`${(e.distance / 1000).toFixed(2)} km`);
+            if (e.calories) subParts.push(`${Math.round(e.calories)} kcal`);
+            if (e.hr_average) subParts.push(`${e.hr_average} bpm avg`);
+
+            stats.push({
+                icon: workoutIcons[e.activity_type] || '🏋️',
+                label: e.activity_type,
+                value: durationStr || new Date(e.timestamp).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' }),
+                sub: subParts.length > 0 ? subParts.join(' · ') : null,
+                note: e.note || null
+            });
+        });
 
         // Sleep (use max record to avoid double-counting segments)
         let sleepDuration = 0;
@@ -255,6 +290,7 @@ export class TimelineDay extends HTMLElement {
         }
         sleepEvents.forEach(e => { if (e.note) dailyNotesList.push({ type: 'Sleep', note: e.note }); });
         activityEvents.forEach(e => { if (e.note) dailyNotesList.push({ type: 'Activity', note: e.note }); });
+        workoutEvents.forEach(e => { if (e.note) dailyNotesList.push({ type: e.activity_type || 'Workout', note: e.note }); });
         nutritionEvents.forEach(e => {
             e.foods.forEach(f => {
                 if (f.note) dailyNotesList.push({ type: `Food (${e.meal_group})`, note: `${f.name}: ${f.note}` });

--- a/src/views/timeline-view.js
+++ b/src/views/timeline-view.js
@@ -7,6 +7,7 @@ import { getDaysWindow, toDayKey } from '../utils/day-range.js';
 const TIMELINE_SOURCES = [
     { table: 'location' },
     { table: 'steps', where: 'count > 0' },
+    { table: 'activities', where: "type IS NOT NULL AND type != 'Walking'" },
     { table: 'weight' },
     { table: 'sleep' },
     { table: 'nutrition_servings' },
@@ -165,6 +166,25 @@ export class TimelineView extends DataView {
                 }
             });
         } catch (e) { console.warn('Steps fetch failed', e); }
+
+        // 2b. Fetch Workouts (any activity that isn't walking)
+        try {
+            read('activities').forEach(row => {
+                if (!row.type || row.type === 'Walking') return;
+                events.push({
+                    timestamp: row.timestamp,
+                    type: 'workout',
+                    activity_type: row.type,
+                    end_timestamp: row.end_timestamp,
+                    calories: row.calories,
+                    distance: row.distance,
+                    steps: row.steps,
+                    elevation: row.elevation,
+                    hr_average: row.hr_average,
+                    note: row.note
+                });
+            });
+        } catch (e) { console.warn('Activities fetch failed', e); }
 
         // 3. Fetch Weight
         try {

--- a/test/timeline-loading.test.js
+++ b/test/timeline-loading.test.js
@@ -12,6 +12,7 @@ import { getDaysWindow, toDayKey } from '../src/utils/day-range.js';
 const SOURCES = [
     { table: 'location' },
     { table: 'steps', where: 'count > 0' },
+    { table: 'activities', where: "type IS NOT NULL AND type != 'Walking'" },
     { table: 'weight' },
     { table: 'sleep' },
     { table: 'nutrition_servings' },


### PR DESCRIPTION
Fixes #10

The timeline now shows every activity that isn't walking.

## Changes
- `src/views/timeline-view.js`: adds the `activities` table to the timeline sources (filtered with `type IS NOT NULL AND type != 'Walking'`, since the Withings importer also stores Walking sessions there) and fetches those rows into `workout` events.
- `src/components/timeline-day.js`: renders one stat line per workout with its type, duration, distance, calories and average heart rate, using a per-type icon (🏃 🚴 🏊 🥾 ⛷️ 🤸). Workout notes are included in the Daily Notes section.
- `test/timeline-loading.test.js`: mirrors the new timeline source list.

Days that only contain a non-walking activity now appear in the timeline as well.

## Screenshot
Cycling and Swimming sessions now appear in the day cards with duration, distance, calories and average heart rate:

![Timeline showing Cycling and Swimming workouts](https://raw.githubusercontent.com/steren/life-dashboard/claude/pr-screenshots/pr31-timeline-workouts.png)

## Testing
`node --test`: 126 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKiHi1UohUe6925kVvX5us