### PR TITLE
Add Daily Energy Cost stacked chart to Energy view

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
         <div class="charts-grid">
             <chart-card title="Electricity: Solar vs Consumption" chart-id="solar-chart"></chart-card>
             <chart-card title="Electricity: Grid Flow" chart-id="grid-flow-chart"></chart-card>
+            <chart-card title="Daily Energy Cost" chart-id="energy-cost-chart"></chart-card>
             <chart-card title="Gas Import" chart-id="gas-chart"></chart-card>
             <chart-card title="Water Usage" chart-id="water-chart"></chart-card>
         </div>

--- a/src/views/energy-view.js
+++ b/src/views/energy-view.js
@@ -52,9 +52,55 @@ export class EnergyView extends DataView {
             [{ label: 'Net Grid (Import-Export)', col: 'net_grid_kwh', color: getChartColor(ChartColors.Orange) }],
             startDate, endDate);
 
+        await this.renderDailyCostChart(startDate, endDate);
+
         await this.createSingleLineChart('gas-chart', 'Gas Import', 'gas_daily', 'usage_therms', getChartColor(ChartColors.Red), startDate, endDate);
 
         await this.createSingleLineChart('water-chart', 'Water Usage', 'water_daily', 'usage_liters', getChartColor(ChartColors.Blue), startDate, endDate);
+    }
+
+    /**
+     * Stacked chart of the daily cost of electricity and gas.
+     * Merges electricity_grid_daily.cost and gas_daily.cost by day.
+     */
+    async renderDailyCostChart(startDate, endDate) {
+        const chartCard = this.querySelector('chart-card[chart-id="energy-cost-chart"]');
+        if (!chartCard) return;
+
+        const costByDay = new Map();
+        const addCosts = (rows, key) => {
+            rows.forEach(row => {
+                if (row.cost == null) return;
+                const dayTs = new Date(row.timestamp).setHours(0, 0, 0, 0);
+                const entry = costByDay.get(dayTs) || { timestamp: dayTs, electricity_cost: null, gas_cost: null };
+                entry[key] = (entry[key] || 0) + row.cost;
+                costByDay.set(dayTs, entry);
+            });
+        };
+
+        addCosts(dataRepository.getTimeSeriesData('electricity_grid_daily', startDate, endDate, 'ASC'), 'electricity_cost');
+        addCosts(dataRepository.getTimeSeriesData('gas_daily', startDate, endDate, 'ASC'), 'gas_cost');
+
+        const data = Array.from(costByDay.values())
+            .map(entry => ({
+                ...entry,
+                electricity_cost: entry.electricity_cost == null ? null : Math.round(entry.electricity_cost * 100) / 100,
+                gas_cost: entry.gas_cost == null ? null : Math.round(entry.gas_cost * 100) / 100
+            }))
+            .sort((a, b) => a.timestamp - b.timestamp);
+
+        chartCard.setDateRange(startDate, endDate);
+        chartCard.setTimeSeriesData(data, {
+            series: [
+                { label: 'Electricity ($)', key: 'electricity_cost', color: getChartColor(ChartColors.Orange) },
+                { label: 'Gas ($)', key: 'gas_cost', color: getChartColor(ChartColors.Red) }
+            ],
+            startDate: startDate,
+            endDate: endDate,
+            interval: 'daily',
+            stacked: true,
+            fill: true
+        });
     }
 
     async createMultiLineChart(chartId, tableName, datasetsConfig, startDate, endDate) {


### PR DESCRIPTION
Fixes #12

Adds a "Daily Energy Cost" stacked chart to the Energy view showing the daily cost of both gas and electricity.

## Changes
- `index.html`: adds the `energy-cost-chart` chart-card to the energy view template.
- `src/views/energy-view.js`: new `renderDailyCostChart()` merges `electricity_grid_daily.cost` and `gas_daily.cost` by day and renders them as a stacked, filled time series using the existing `chart-card` stacking support (raw daily values plus stacked 7-day average lines). Costs are rounded to cents; days missing from one source keep `null` for that series rather than a fake zero.

## Screenshot
Gas (orange) and electricity (red) daily cost, stacked — the seasonal electric heating cost is clearly visible:

![Daily Energy Cost stacked chart](https://raw.githubusercontent.com/steren/life-dashboard/claude/pr-screenshots/pr33-energy-cost-chart.png)

## Testing
`node --test`: 126 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKiHi1UohUe6925kVvX5us