### PR TITLE
Add GitHub Actions workflow running the Node.js tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: node --test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run tests
+        run: node --test


### PR DESCRIPTION
Adds `.github/workflows/tests.yml`, a CI workflow that runs the project's test suite.

## What it does

- Runs `node --test` (the command documented in the README) on:
  - pushes to `main`
  - every pull request
  - manual `workflow_dispatch`
- Matrix over Node.js 22.x and 24.x, with `fail-fast: false` so one version's failure doesn't hide the other's result.
- Steps are just `actions/checkout@v4` + `actions/setup-node@v4` + `node --test` — no install step, since the project has no dependencies (no `package.json`, vendored browser libs).

## Verification

Ran `node --test` locally on Node v22.22.2: 126 tests across 12 suites, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpArdncEL3SsPmuEMEFJo7)_