### PR TITLE
Bump checkout and setup-node actions to v5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Follow-up to #34.

`actions/checkout@v4` and `actions/setup-node@v4` target Node.js 20, which GitHub is deprecating on the runners. The #34 run passed but logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

v5 of both actions runs on the current runner default natively, so the warning goes away.

The test matrix itself is unchanged — `node --test` still runs on Node.js 22.x and 24.x.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpArdncEL3SsPmuEMEFJo7)_