### PR TITLE
Add pagination support to raw data explorer

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,11 @@
                         <tbody></tbody>
                     </table>
                 </div>
+                <nav id="data-pagination" class="table-pagination" aria-label="Data pages" hidden>
+                    <button id="data-page-prev" class="pagination-btn" type="button" aria-label="Previous page">&lt;</button>
+                    <span id="data-page-label"></span>
+                    <button id="data-page-next" class="pagination-btn" type="button" aria-label="Next page">&gt;</button>
+                </nav>
             </section>
         </div>
     </template>

--- a/src/services/data-repository.js
+++ b/src/services/data-repository.js
@@ -57,6 +57,56 @@ export function insertRecord(tableName, data) {
     );
 }
 
+// --- Raw data explorer ---
+
+// Column names that hold the date of a row, by order of preference.
+const DATE_COLUMNS = ['timestamp', 'time', 'date', 'time_watched', 'created_at', 'datetime'];
+
+/**
+ * Reads one page of a table, most recent rows first when the table has a date
+ * column. Only the requested page is read from the database, and the total
+ * number of matching rows is returned so the caller can render page controls.
+ * @param {string} tableName
+ * @param {object} [options]
+ * @param {string} [options.startDate] 'YYYY-MM-DD', only with endDate
+ * @param {string} [options.endDate] 'YYYY-MM-DD', only with startDate
+ * @param {number} [options.page] 1-based page number, clamped to the last page
+ * @param {number} [options.pageSize] rows per page
+ * @returns {{rows: object[], dateColumn: string|null, totalRows: number, page: number, pageCount: number, offset: number}}
+ */
+export function getTablePage(tableName, { startDate, endDate, page = 1, pageSize = 100 } = {}) {
+    const columnNames = getTableColumns(tableName).map(c => c.name);
+    const dateColumn = DATE_COLUMNS.find(col => columnNames.includes(col)) || null;
+
+    if (columnNames.length === 0) {
+        return { rows: [], dateColumn: null, totalRows: 0, page: 1, pageCount: 1, offset: 0 };
+    }
+
+    let where = '';
+    const params = [];
+    if (dateColumn && startDate && endDate) {
+        where = ` WHERE "${dateColumn}" >= ? AND "${dateColumn}" <= ?`;
+        // Local day boundaries
+        params.push(new Date(startDate + 'T00:00:00').getTime());
+        params.push(new Date(endDate + 'T23:59:59.999').getTime());
+    }
+
+    const countRows = dbService.query(`SELECT COUNT(*) AS count FROM "${tableName}"${where}`, params);
+    const totalRows = countRows.length > 0 ? countRows[0].count : 0;
+
+    const pageCount = Math.max(1, Math.ceil(totalRows / pageSize));
+    const currentPage = Math.min(Math.max(1, page), pageCount);
+    const offset = (currentPage - 1) * pageSize;
+
+    let query = `SELECT * FROM "${tableName}"${where}`;
+    if (dateColumn) query += ` ORDER BY "${dateColumn}" DESC`;
+    query += ` LIMIT ? OFFSET ?`;
+
+    const rows = dbService.query(query, [...params, pageSize, offset]);
+
+    return { rows, dateColumn, totalRows, page: currentPage, pageCount, offset };
+}
+
 // --- Finance ---
 
 export function getAccounts() {

--- a/src/views/health/dives-view.js
+++ b/src/views/health/dives-view.js
@@ -328,32 +328,8 @@ export class HealthDivesView extends DataView {
                     height: 200px;
                 }
                 
-                .table-pagination {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    margin-top: 0.5rem;
-                    font-size: 0.8rem;
-                }
-                
-                .pagination-btn {
-                    background: none;
-                    border: 1px solid var(--border-color);
-                    color: var(--text-color);
-                    cursor: pointer;
-                    padding: 0.25rem 0.5rem;
-                    font-weight: bold;
-                }
-                
-                .pagination-btn:hover {
-                    background: var(--border-color);
-                }
-                
-                .pagination-btn[disabled] {
-                    opacity: 0.4;
-                    cursor: not-allowed;
-                }
-                
+                /* .table-pagination and .pagination-btn come from style.css */
+
                 .mini-table {
                     width: 100%;
                     border-collapse: collapse;

--- a/src/views/raw-data-view.js
+++ b/src/views/raw-data-view.js
@@ -1,10 +1,14 @@
 import * as dataRepository from '../services/data-repository.js';
 import { DataView } from '../components/data-view/data-view.js';
 
+const ROWS_PER_PAGE = 100;
+
 export class RawDataView extends DataView {
     constructor() {
         super();
         this.currentTable = null;
+        this.page = 1;
+        this.pageCount = 1;
     }
 
     connectedCallback() {
@@ -130,6 +134,7 @@ export class RawDataView extends DataView {
     }
 
     onDateRangeChanged() {
+        this.page = 1;
         this.loadTableData();
     }
 
@@ -195,9 +200,15 @@ export class RawDataView extends DataView {
 
         select.addEventListener('change', (e) => {
             this.currentTable = e.target.value;
+            this.page = 1;
             this.resetAddRow();
             this.loadTableData();
         });
+
+        const prevBtn = this.querySelector('#data-page-prev');
+        const nextBtn = this.querySelector('#data-page-next');
+        if (prevBtn) prevBtn.addEventListener('click', () => this.goToPage(this.page - 1));
+        if (nextBtn) nextBtn.addEventListener('click', () => this.goToPage(this.page + 1));
 
         const addRowBtn = this.querySelector('#add-row-btn');
         const addRowForm = this.querySelector('#add-row-form');
@@ -346,53 +357,34 @@ export class RawDataView extends DataView {
         }
     }
 
+    /**
+     * Shows another page of the current table. Out of range pages are ignored,
+     * so the buttons stay harmless at the first and last page.
+     */
+    goToPage(page) {
+        if (page < 1 || page > this.pageCount) return;
+        this.page = page;
+        this.loadTableData();
+    }
+
     async loadTableData() {
         if (!this.currentTable) return;
 
         await this.showLoading();
 
         try {
+            const { rows: data, dateColumn, totalRows, page, pageCount, offset } = dataRepository.getTablePage(
+                this.currentTable,
+                {
+                    startDate: this.startDate,
+                    endDate: this.endDate,
+                    page: this.page,
+                    pageSize: ROWS_PER_PAGE
+                }
+            );
 
-
-            const startDate = this.startDate;
-            const endDate = this.endDate;
-
-            let query = `SELECT * FROM "${this.currentTable}"`;
-            let params = [];
-            let dateColumn = null;
-
-            // Detect date column by checking first row or schema
-            // Simplest way: check column names from a limit 1 query
-            const schemaCheck = dataRepository.executeQuery(`SELECT * FROM "${this.currentTable}" LIMIT 1`);
-            if (schemaCheck.length > 0) {
-                const cols = Object.keys(schemaCheck[0]);
-                // Priority list of date column names
-                const dateCols = ['timestamp', 'time', 'date', 'time_watched', 'created_at', 'datetime'];
-                dateColumn = dateCols.find(col => cols.includes(col));
-            }
-
-            if (dateColumn && startDate && endDate) {
-                query += ` WHERE "${dateColumn}" >= ? AND "${dateColumn}" <= ?`;
-                // Convert to integer timestamp (Local Day)
-                const startTs = new Date(startDate + 'T00:00:00').getTime();
-                const endTs = new Date(endDate + 'T23:59:59.999').getTime();
-                params.push(startTs);
-                params.push(endTs);
-                query += ` ORDER BY "${dateColumn}" DESC`;
-            } else if (dateColumn) {
-                query += ` ORDER BY "${dateColumn}" DESC`;
-            }
-
-            query += ` LIMIT 100`;
-
-            const data = dataRepository.executeQuery(query, params);
-
-            if (data.length > 0) {
-                // Loaded data
-            } else {
-                // If data is empty, we can't easily see columns unless we use PRAGMA
-                const info = dataRepository.executeQuery(`PRAGMA table_info("${this.currentTable}")`);
-            }
+            this.page = page;
+            this.pageCount = pageCount;
 
             const table = this.querySelector('#data-table');
             const thead = table.querySelector('thead');
@@ -405,10 +397,15 @@ export class RawDataView extends DataView {
 
             if (data.length === 0) {
                 tbody.innerHTML = '<tr><td class="table-empty-message">No data found</td></tr>';
+                this.renderPagination(1);
                 return;
             }
 
-            countSpan.textContent = `Showing ${data.length} rows` + (dateColumn ? ` (sorted by ${dateColumn})` : '');
+            const firstRow = offset + 1;
+            const lastRow = offset + data.length;
+            countSpan.textContent = `Showing rows ${firstRow}-${lastRow} of ${totalRows}` +
+                (dateColumn ? ` (sorted by ${dateColumn})` : '');
+            this.renderPagination(pageCount);
 
             // Headers
             const columns = Object.keys(data[0]);
@@ -495,6 +492,23 @@ export class RawDataView extends DataView {
         } finally {
             this.hideLoading();
         }
+    }
+
+    /**
+     * Updates the page controls below the table. They stay hidden as long as
+     * the whole result fits on a single page.
+     */
+    renderPagination(pageCount) {
+        const pagination = this.querySelector('#data-pagination');
+        const prevBtn = this.querySelector('#data-page-prev');
+        const nextBtn = this.querySelector('#data-page-next');
+        const label = this.querySelector('#data-page-label');
+        if (!pagination || !prevBtn || !nextBtn || !label) return;
+
+        pagination.hidden = pageCount <= 1;
+        label.textContent = `Page ${this.page} of ${pageCount}`;
+        prevBtn.disabled = this.page <= 1;
+        nextBtn.disabled = this.page >= pageCount;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -372,6 +372,38 @@ input:focus {
     color: var(--primary-text);
 }
 
+/* Page controls of a table showing one page of a larger set of rows */
+.table-pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+}
+
+.table-pagination[hidden] {
+    display: none;
+}
+
+.pagination-btn {
+    background: none;
+    border: 1px solid var(--border-color);
+    color: var(--text-color);
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    font-weight: bold;
+}
+
+.pagination-btn:hover:not([disabled]) {
+    background: var(--primary-color);
+    color: var(--primary-text);
+}
+
+.pagination-btn[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 
 /* View Specific Padding */
 finance-view,

--- a/test/raw-data-pagination.test.js
+++ b/test/raw-data-pagination.test.js
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { dbService } from '../src/db.js';
+import { getTablePage } from '../src/services/data-repository.js';
+
+// Work on a copy: connecting runs schema migrations that would modify demo.sqlite.
+function connectToDemoCopy() {
+    const source = path.resolve(import.meta.dirname, '../demo.sqlite');
+    const copy = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'life-dashboard-')), 'demo.sqlite');
+    fs.copyFileSync(source, copy);
+    return dbService.connectNode(copy);
+}
+
+// A table with more rows than a page holds, to exercise paging.
+const TABLE = 'location';
+const PAGE_SIZE = 10;
+
+test('getTablePage reads one page at a time, most recent first', async () => {
+    await connectToDemoCopy();
+    const totalRows = dbService.query(`SELECT COUNT(*) AS count FROM ${TABLE}`)[0].count;
+    assert.ok(totalRows > PAGE_SIZE, `expected ${TABLE} to hold more than ${PAGE_SIZE} rows`);
+
+    const first = getTablePage(TABLE, { page: 1, pageSize: PAGE_SIZE });
+    assert.strictEqual(first.rows.length, PAGE_SIZE);
+    assert.strictEqual(first.totalRows, totalRows);
+    assert.strictEqual(first.dateColumn, 'timestamp');
+    assert.strictEqual(first.page, 1);
+    assert.strictEqual(first.offset, 0);
+    assert.strictEqual(first.pageCount, Math.ceil(totalRows / PAGE_SIZE));
+
+    const timestamps = first.rows.map(r => r.timestamp);
+    assert.deepStrictEqual(timestamps, [...timestamps].sort((a, b) => b - a));
+
+    const second = getTablePage(TABLE, { page: 2, pageSize: PAGE_SIZE });
+    assert.strictEqual(second.offset, PAGE_SIZE);
+    assert.strictEqual(second.rows.length, PAGE_SIZE);
+    // Pages do not overlap and stay in order.
+    const firstIds = new Set(first.rows.map(r => r.id));
+    assert.ok(second.rows.every(r => !firstIds.has(r.id)));
+    assert.ok(second.rows[0].timestamp <= first.rows[first.rows.length - 1].timestamp);
+});
+
+test('getTablePage clamps the page number to the available pages', async () => {
+    await connectToDemoCopy();
+    const { pageCount } = getTablePage(TABLE, { pageSize: PAGE_SIZE });
+
+    const beyondLast = getTablePage(TABLE, { page: pageCount + 50, pageSize: PAGE_SIZE });
+    assert.strictEqual(beyondLast.page, pageCount);
+    assert.ok(beyondLast.rows.length > 0);
+
+    const beforeFirst = getTablePage(TABLE, { page: 0, pageSize: PAGE_SIZE });
+    assert.strictEqual(beforeFirst.page, 1);
+    assert.strictEqual(beforeFirst.offset, 0);
+});
+
+test('getTablePage counts only the rows of the date range', async () => {
+    await connectToDemoCopy();
+    const totalRows = dbService.query(`SELECT COUNT(*) AS count FROM ${TABLE}`)[0].count;
+
+    // Local day of the most recent row, the same way the view builds its range.
+    const latest = new Date(getTablePage(TABLE, { pageSize: 1 }).rows[0].timestamp);
+    const day = [
+        latest.getFullYear(),
+        String(latest.getMonth() + 1).padStart(2, '0'),
+        String(latest.getDate()).padStart(2, '0')
+    ].join('-');
+
+    const dayPage = getTablePage(TABLE, { startDate: day, endDate: day, pageSize: PAGE_SIZE });
+    const expected = dbService.query(
+        `SELECT COUNT(*) AS count FROM ${TABLE} WHERE timestamp >= ? AND timestamp <= ?`,
+        [new Date(day + 'T00:00:00').getTime(), new Date(day + 'T23:59:59.999').getTime()]
+    )[0].count;
+
+    assert.ok(expected > 0 && expected < totalRows);
+    assert.strictEqual(dayPage.totalRows, expected);
+    assert.strictEqual(dayPage.pageCount, Math.max(1, Math.ceil(expected / PAGE_SIZE)));
+});
+
+test('getTablePage returns an empty page for an unknown table', async () => {
+    await connectToDemoCopy();
+    const result = getTablePage('no_such_table', { pageSize: PAGE_SIZE });
+    assert.deepStrictEqual(result.rows, []);
+    assert.strictEqual(result.totalRows, 0);
+    assert.strictEqual(result.pageCount, 1);
+});


### PR DESCRIPTION
## Summary
Implements pagination for the raw data explorer view to handle tables with large numbers of rows. Previously, the view would load only the first 100 rows without any indication of how many total rows existed. Now it displays one page at a time with navigation controls and row count information.

## Key Changes
- **New `getTablePage()` function** in `data-repository.js` that handles paginated queries with date filtering, returning metadata about total rows, page count, and current offset
- **Pagination UI controls** added to `index.html` with previous/next buttons and page indicator
- **Page state management** in `RawDataView` with `page` and `pageCount` properties that reset when changing tables or date ranges
- **`goToPage()` method** that validates page numbers and reloads table data, with bounds checking to prevent invalid page requests
- **`renderPagination()` method** that updates button states and visibility based on whether results span multiple pages
- **Improved row count display** showing "Showing rows X-Y of Z" instead of just the current page size
- **Shared pagination styles** moved to global `style.css` and removed from `dives-view.js` to avoid duplication
- **Comprehensive test suite** (`raw-data-pagination.test.js`) covering page navigation, date range filtering, boundary conditions, and edge cases

## Implementation Details
- Page numbers are 1-based and automatically clamped to valid ranges (1 to pageCount)
- Pagination controls are hidden when results fit on a single page
- Date range filtering is applied before pagination, so total row counts reflect the filtered set
- The `ROWS_PER_PAGE` constant (100) is configurable and used consistently across the view
- Pagination state resets to page 1 when the user changes tables or adjusts date filters

https://claude.ai/code/session_01FzrMBJ9L3thCPngFSMKDfr