### PR TITLE
Fix timeline scrollbar to reflect full selected range

### DIFF
--- a/src/utils/timeline-scroll.js
+++ b/src/utils/timeline-scroll.js
@@ -1,0 +1,17 @@
+/**
+ * Helpers keeping the timeline scrollbar the size of the whole selected range,
+ * even though days are rendered in batches as the user scrolls.
+ */
+
+/**
+ * Height to reserve below the rendered days so the scrollbar already accounts
+ * for the days still to be rendered.
+ * @param {number} renderedHeight height taken by the days rendered so far, in pixels
+ * @param {number} renderedDays number of days rendered so far
+ * @param {number} pendingDays number of days left to render
+ * @returns {number} height to reserve, in pixels
+ */
+export function estimatePendingHeight(renderedHeight, renderedDays, pendingDays) {
+    if (pendingDays <= 0 || renderedDays <= 0 || renderedHeight <= 0) return 0;
+    return Math.round((renderedHeight / renderedDays) * pendingDays);
+}

--- a/src/views/timeline-view.js
+++ b/src/views/timeline-view.js
@@ -2,6 +2,7 @@ import * as dataRepository from '../services/data-repository.js';
 import { DataView } from '../components/data-view/data-view.js';
 import '../components/timeline-day.js';
 import { getDaysWindow, toDayKey } from '../utils/day-range.js';
+import { estimatePendingHeight } from '../utils/timeline-scroll.js';
 
 // Tables feeding the timeline, with the condition qualifying a row as an event.
 const TIMELINE_SOURCES = [
@@ -31,6 +32,7 @@ export class TimelineView extends DataView {
         this.isLoadingChunk = false;
         this.sentinel = null;
         this.sentinelObserver = null;
+        this.spacer = null;
     }
 
     connectedCallback() {
@@ -121,6 +123,7 @@ export class TimelineView extends DataView {
         }
 
         requestAnimationFrame(() => {
+            this.updateSpacer();
             this.updateScale(this.days.slice(0, this.loadedDays));
             // The batch may not fill the viewport: keep loading until it does.
             this.loadMoreIfSentinelVisible();
@@ -341,13 +344,21 @@ export class TimelineView extends DataView {
     }
 
     /**
-     * Appends the element observed to trigger loading of the next batch of days.
+     * Appends the element observed to trigger loading of the next batch of days,
+     * followed by the spacer standing in for the days not rendered yet.
      */
     setupSentinel(content) {
         this.sentinel = document.createElement('div');
         this.sentinel.className = 'timeline-sentinel';
         this.sentinel.textContent = 'Loading more…';
         content.appendChild(this.sentinel);
+
+        // Below the sentinel, so scrolling to the end of the rendered days still
+        // triggers the next batch rather than landing in the reserved space.
+        this.spacer = document.createElement('div');
+        this.spacer.className = 'timeline-spacer';
+        this.spacer.setAttribute('aria-hidden', 'true');
+        content.appendChild(this.spacer);
 
         this.sentinelObserver = new IntersectionObserver(entries => {
             if (entries.some(entry => entry.isIntersecting)) this.loadNextChunk();
@@ -365,6 +376,31 @@ export class TimelineView extends DataView {
             this.sentinel.remove();
             this.sentinel = null;
         }
+        if (this.spacer) {
+            this.spacer.remove();
+            this.spacer = null;
+        }
+    }
+
+    /**
+     * Keeps the scrollbar the size of the whole selected range by reserving, below
+     * the rendered days, the height the days still to render are expected to take.
+     */
+    updateSpacer() {
+        if (!this.spacer) return;
+
+        const content = this.querySelector('#timeline-content');
+        if (!content) return;
+
+        const dayEls = Array.from(content.children).filter(el => el.tagName === 'TIMELINE-DAY');
+        if (dayEls.length === 0) return;
+
+        const first = dayEls[0];
+        const last = dayEls[dayEls.length - 1];
+        const renderedHeight = last.offsetTop + last.offsetHeight - first.offsetTop;
+
+        const pending = estimatePendingHeight(renderedHeight, dayEls.length, this.days.length - this.loadedDays);
+        this.spacer.style.height = `${pending}px`;
     }
 
     /**
@@ -517,6 +553,10 @@ export class TimelineView extends DataView {
 
         this.isScrolling = true;
         this.updateIndicator();
+
+        // A jump into the reserved space leaves the sentinel behind, out of the
+        // observer's reach: check it on every scroll so days keep loading.
+        this.loadMoreIfSentinelVisible();
 
         clearTimeout(this._scrollTimeout);
         this._scrollTimeout = setTimeout(() => {

--- a/style.css
+++ b/style.css
@@ -480,6 +480,14 @@ map-view {
     font-size: 0.8rem;
     text-transform: uppercase;
     opacity: 0.7;
+    overflow-anchor: none;
+}
+
+/* Stands in for the days not rendered yet, so the scrollbar reflects the whole selected range */
+.timeline-spacer {
+    pointer-events: none;
+    /* Never anchor scrolling here: days loading above the spacer would push the view down */
+    overflow-anchor: none;
 }
 
 .timeline-content .no-data {

--- a/test/timeline-scroll.test.js
+++ b/test/timeline-scroll.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { estimatePendingHeight } from '../src/utils/timeline-scroll.js';
+
+test('estimatePendingHeight extrapolates from the days rendered so far', () => {
+    // 10 days taking 2000px average 200px per day, 40 days left to render.
+    assert.strictEqual(estimatePendingHeight(2000, 10, 40), 8000);
+    assert.strictEqual(estimatePendingHeight(1500, 10, 5), 750);
+    assert.strictEqual(estimatePendingHeight(100, 3, 1), 33);
+});
+
+test('estimatePendingHeight reserves nothing without days left or measurements', () => {
+    assert.strictEqual(estimatePendingHeight(2000, 10, 0), 0);
+    assert.strictEqual(estimatePendingHeight(2000, 10, -1), 0);
+    assert.strictEqual(estimatePendingHeight(2000, 0, 40), 0);
+    assert.strictEqual(estimatePendingHeight(0, 10, 40), 0);
+});
+
+test('the reserved height keeps the total close to the fully rendered timeline', () => {
+    const dayHeights = Array.from({ length: 50 }, (_, i) => 150 + (i % 7) * 30);
+    const fullHeight = dayHeights.reduce((sum, height) => sum + height, 0);
+
+    // Estimating after each batch should stay within a reasonable margin of the final height.
+    for (let rendered = 10; rendered < dayHeights.length; rendered += 10) {
+        const renderedHeight = dayHeights.slice(0, rendered).reduce((sum, height) => sum + height, 0);
+        const estimated = renderedHeight + estimatePendingHeight(renderedHeight, rendered, dayHeights.length - rendered);
+        assert.ok(Math.abs(estimated - fullHeight) / fullHeight < 0.1, `estimate ${estimated} should be close to ${fullHeight}`);
+    }
+});


### PR DESCRIPTION
## Summary
This PR improves the timeline scrollbar behavior when loading days in batches. Previously, the scrollbar would only reflect the height of rendered days, making it appear as though there was less content than actually existed. Now, a spacer element reserves space below the rendered days for content still being loaded, keeping the scrollbar proportional to the entire selected date range.

## Key Changes
- **New utility module** (`src/utils/timeline-scroll.js`): Added `estimatePendingHeight()` function that calculates the height to reserve based on the average height of rendered days and the number of days still pending
- **Spacer element**: Added a `timeline-spacer` div that is appended after the sentinel and dynamically sized to reserve space for unrendered days
- **Dynamic spacer updates**: Call `updateSpacer()` during each batch load to recalculate the reserved height based on actual rendered day heights
- **Scroll handling**: Added `loadMoreIfSentinelVisible()` check during scroll events to handle cases where users jump into the reserved space, leaving the sentinel out of view
- **Styling**: Added `overflow-anchor: none` to both sentinel and spacer to prevent scroll anchoring issues when new days load above them
- **Comprehensive tests**: Added test suite validating the height estimation logic and verifying accuracy across multiple batch loads

## Implementation Details
- The spacer height is calculated by averaging the height of rendered days and extrapolating for pending days: `(renderedHeight / renderedDays) × pendingDays`
- The spacer is positioned after the sentinel so scrolling to the end of rendered content still triggers the next batch load
- Both sentinel and spacer have `overflow-anchor: none` to prevent the browser's scroll anchoring from interfering with the loading experience
- The spacer is marked with `aria-hidden="true"` since it's purely a visual/UX element with no semantic content

https://claude.ai/code/session_013tg2jnEox6tReugb7bEbEX